### PR TITLE
Pipeline improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,5 @@
 name: Developer checks
 on:
-    push:
-        branches-ignore:
-            - develop
-            - main
     pull_request:
         branches:
             - develop

--- a/Layouts/Layout.js
+++ b/Layouts/Layout.js
@@ -35,12 +35,12 @@ export default function Layout({ children }) {
 			</a>
 
 			{process.env.NODE_ENV === "production" &&
-			process.env.VERCEL_ENV === "production" ? null : (
+			process.env.NEXT_PUBLIC_VERCEL_ENV === "production" ? null : (
 				<div className="notification is-warning mb-0">
 					<p>
 						This is a{" "}
-						{process.env.VERCEL_ENV
-							? process.env.VERCEL_ENV
+						{process.env.NEXT_PUBLIC_VERCEL_ENV
+							? process.env.NEXT_PUBLIC_VERCEL_ENV
 							: "local"}{" "}
 						instance running in {process.env.NODE_ENV} mode
 					</p>

--- a/vercel.sh
+++ b/vercel.sh
@@ -7,6 +7,9 @@ if [ "$VERCEL_GIT_COMMIT_REF" == "main" ]; then
 elif [ "$VERCEL_GIT_COMMIT_REF" == "develop" ]; then
   echo "✅ - Building and deploying to dev.helbling.uk"
   exit 1;
+elif [ "${VERCEL_GIT_COMMIT_REF:0:7}" == "vercel/" ]; then
+  echo "✅ - Building and deploying to dev.helbling.uk"
+  exit 1;
 else
   echo "🛑 - Build cancelled"
   exit 0;


### PR DESCRIPTION
- Only run builds on MRs
- Display nonprod banners correctly in vercel
- Always deploy branches starting with `vercel/` as they likely require deployment to validate their functionality