### PR TITLE
Include www in sitemap generator

### DIFF
--- a/sitemapgen.js
+++ b/sitemapgen.js
@@ -9,7 +9,7 @@ const priorities = {
 const defaultPriority = 0.3;
 const xmlHead = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">`;
 const xmlFoot = `</urlset>`;
-const sitebase = "https://helbling.uk";
+const sitebase = "https://www.helbling.uk";
 
 async function getFiles(path = "./pages/") {
 	const entries = await fs.promises.readdir(path, { withFileTypes: true });


### PR DESCRIPTION
Google search console reports that all pages are not indexed because of this. This might also be why removed pages like /background still show up in google